### PR TITLE
added better postprocessing for greyscale maps

### DIFF
--- a/node.py
+++ b/node.py
@@ -39,8 +39,8 @@ def postprocess_inferno(depths):
     depth_frames = []
     for i in range(depths.shape[0]):
         depth = depths[i]
-        depth_norm = ((depth - d_min) / (d_max - d_min) * 65535).astype(np.uint16)
-        depth_vis = (colormap[depth_norm] * 65535).astype(np.uint16)
+        depth_norm = ((depth - d_min) / (d_max - d_min) * 255).astype(np.uint8)
+        depth_vis = (colormap[depth_norm] * 255).astype(np.uint8)
         depth_frames.append(depth_vis)
     return torch.from_numpy(np.array(depth_frames).astype(np.float32) / 255.0)
 


### PR DESCRIPTION
I changed the postprocess method to get rid of the annoying banding issues.
Even the small model now leads to a lot less banding. 
I also improved efficiency of the numpy-tensor operations

Before:
![before](https://github.com/user-attachments/assets/23114d4b-ffca-40ae-a57a-3ea0d2fa2abf)

After:
![after](https://github.com/user-attachments/assets/8ab88831-bc8c-4680-8fd4-76ded6a60394)
